### PR TITLE
[metabase] Update to use hyphen based args

### DIFF
--- a/.github/workflows/trunk-hourly-e2e-tests.yml
+++ b/.github/workflows/trunk-hourly-e2e-tests.yml
@@ -127,8 +127,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: cypress/reports/**/*junit*.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: cypress/reports/**/*junit*.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
         env:
           TRUNK_LOG: info
@@ -147,8 +147,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: cypress/reports/**/*junit*.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: cypress/reports/**/*junit*.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
         env:
           TRUNK_LOG: info
@@ -167,8 +167,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: cypress/reports/**/*junit*.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: cypress/reports/**/*junit*.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
         env:
           TRUNK_LOG: info
@@ -188,8 +188,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: cypress/reports/**/*junit*.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: cypress/reports/**/*junit*.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
         env:
           TRUNK_LOG: info
@@ -210,8 +210,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: cypress/reports/**/*junit*.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: cypress/reports/**/*junit*.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
         env:
           TRUNK_LOG: info
@@ -221,8 +221,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: cypress/reports/**/*junit*.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: cypress/reports/**/*junit*.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
           tags: tests=e2e
         env:

--- a/.github/workflows/trunk-hourly-e2e-tests.yml
+++ b/.github/workflows/trunk-hourly-e2e-tests.yml
@@ -125,6 +125,7 @@ jobs:
 
       - run: ls -l ./cypress/reports/mochareports/
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: cypress/reports/**/*junit*.xml
@@ -145,6 +146,7 @@ jobs:
 
       - run: ls -l ./cypress/reports/mochareports/
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: cypress/reports/**/*junit*.xml
@@ -165,6 +167,7 @@ jobs:
 
       - run: ls -l ./cypress/reports/mochareports/
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: cypress/reports/**/*junit*.xml
@@ -186,6 +189,7 @@ jobs:
 
       - run: ls -l ./cypress/reports/mochareports/
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: cypress/reports/**/*junit*.xml
@@ -208,6 +212,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: cypress/reports/**/*junit*.xml
@@ -219,6 +224,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: cypress/reports/**/*junit*.xml

--- a/.github/workflows/trunk-hourly-tests.yml
+++ b/.github/workflows/trunk-hourly-tests.yml
@@ -46,6 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload results
+        if: "!cancelled()"
         uses: trunk-io/analytics-uploader@main
         with:
           junit-paths: target/junit/**/*_test.xml

--- a/.github/workflows/trunk-hourly-tests.yml
+++ b/.github/workflows/trunk-hourly-tests.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Upload results
         uses: trunk-io/analytics-uploader@main
         with:
-          junit_paths: target/junit/**/*_test.xml
-          org_url_slug: trunk-staging-org
+          junit-paths: target/junit/**/*_test.xml
+          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
         env:
           TRUNK_LOG: info


### PR DESCRIPTION
- as per changes in https://github.com/trunk-io/analytics-uploader/pull/10
- also we want to upload the results whether the tests pass or fail (hence the `if: "!cancelled()"`)